### PR TITLE
Update or-tools layer to python3.8

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 
+set -ex
+
 export PKG_DIR="python"
 
 rm -rf ${PKG_DIR} && mkdir -p ${PKG_DIR}
 
-docker run --rm -v $(pwd):/foo -w /foo lambci/lambda:build-python3.6 \
+docker run --rm -v $(pwd):/foo -w /foo lambci/lambda:build-python3.8 \
 pip install -r requirements.txt --no-deps -t ${PKG_DIR}
 
 zip -r or-tools-layer.zip .


### PR DESCRIPTION
Also adds error handling - the first time I ran this locally docker failed but script continued and created an empty zip file.